### PR TITLE
Be STI friendly

### DIFF
--- a/lib/carrierwave-serializable/orm/activerecord.rb
+++ b/lib/carrierwave-serializable/orm/activerecord.rb
@@ -6,7 +6,7 @@ module CarrierWave
   module ActiveRecord
     module Serializable
       def serialized_uploaders
-        @serialized_uploaders ||= {}
+        @serialized_uploaders ||= superclass.respond_to?(:serialized_uploaders) ? superclass.serialized_uploaders.dup : {}
       end
 
       def serialized_uploader?(column)


### PR DESCRIPTION
A serialize_to mounted uploader did not work in an inherited record, because the internal housekeeping did not take that scenario into account. I hope I fixed that. A quick test here looks OK...
