### PR TITLE
read_uploader fixed for using with FactoryGirl

### DIFF
--- a/lib/carrierwave-serializable/orm/activerecord.rb
+++ b/lib/carrierwave-serializable/orm/activerecord.rb
@@ -63,7 +63,7 @@ module CarrierWave
           def read_uploader(column)
             if self.class.serialized_uploader?(column)
               serialized_field = self.send self.class.serialized_uploaders[column]
-              serialized_field[column.to_s]
+              serialized_field ? serialized_field[column.to_s] : nil
             else
               read_attribute(column)
             end


### PR DESCRIPTION
When serialized column is nil it is not possible to read uploader
