### PR TITLE
Dup the superclass uploaders instead of ignoring them.

### DIFF
--- a/lib/carrierwave-serializable/orm/activerecord.rb
+++ b/lib/carrierwave-serializable/orm/activerecord.rb
@@ -6,7 +6,7 @@ module CarrierWave
   module ActiveRecord
     module Serializable
       def serialized_uploaders
-        @serialized_uploaders ||= read_from_superclass? ? superclass.serialized_uploaders : {}
+        @serialized_uploaders ||= superclass.respond_to?(:serialized_uploaders) ? superclass.serialized_uploaders.dup : {}
       end
 
       def serialized_uploader?(column)
@@ -59,12 +59,6 @@ module CarrierWave
           end
         RUBY
 
-      end
-
-      private
-
-      def read_from_superclass?
-        superclass != ::ActiveRecord::Base && superclass.respond_to?(:serialized_uploaders)
       end
     end # Serializable
   end # ActiveRecord


### PR DESCRIPTION
This commit is prompted by the upcoming move to `ApplicationRecord` in Rails 5.

To accomodate `ApplicationRecord`, we could exclude checking for uploaders there, just as we do on `ActiveRecord::Base`. But, it seems wrong to a priori exclude this behavior: `ApplicationRecord` is meant to be a place to define behavior common to all models, and it should be possible to include an uploader across all models if desired.

Thus, we are taking a different (and better) approach here. The problem before was that uploaders were getting added into the `ActiveRecord::Base.serialized_uploaders` hash, and then inappropriately getting exposed to other models. By duping the hash, we should be able to have uploaders added at any point in the chain.
