### PR TITLE
Prevent uploaders sharing between models by duplicating uploaders list.

### DIFF
--- a/lib/carrierwave-serializable/orm/activerecord.rb
+++ b/lib/carrierwave-serializable/orm/activerecord.rb
@@ -6,7 +6,7 @@ module CarrierWave
   module ActiveRecord
     module Serializable
       def serialized_uploaders
-        @serialized_uploaders ||= read_from_superclass? ? superclass.serialized_uploaders : {}
+        @serialized_uploaders ||= read_from_superclass? ? superclass.serialized_uploaders.dup : {}
       end
 
       def serialized_uploader?(column)

--- a/spec/integration_spec.rb
+++ b/spec/integration_spec.rb
@@ -1,30 +1,48 @@
 RSpec.describe 'Integration' do
   ActiveRecord::Base.establish_connection adapter: 'sqlite3', database: ':memory:'
-  ActiveRecord::Base.raise_in_transactional_callbacks = true
   ActiveRecord::Migration.verbose = false
 
-  class TestMigration < ActiveRecord::Migration
+  class TestMigration < ActiveRecord::Migration[4.2]
     def self.up
-      create_table :images, :force => true do |t|
+      create_table :avatars, force: true do |t|
+        t.column :image1, :text
+      end
+
+      create_table :images, force: true do |t|
         t.column :data, :text
       end
     end
 
     def self.down
+      drop_table :avatars
       drop_table :images
     end
   end
 
   class ImageUploader < CarrierWave::Uploader::Base; end
 
-  class Image < ActiveRecord::Base
+  class ApplicationRecord < ActiveRecord::Base
+    self.abstract_class = true
+
+    mount_uploader :base_image, ImageUploader, serialize_to: :data
+  end
+
+  class Avatar < ApplicationRecord
+    mount_uploader :image1, ImageUploader
+  end
+
+  class Image < ApplicationRecord
     serialize :data, Hash
     mount_uploader :image1, ImageUploader, serialize_to: :data
   end
 
   before(:all) { TestMigration.up }
   after(:all) { TestMigration.down }
-  after { Image.destroy_all }
+
+  after do
+    Avatar.destroy_all
+    Image.destroy_all
+  end
 
   let(:image) { Image.new }
 
@@ -38,6 +56,27 @@ RSpec.describe 'Integration' do
       image.save!
 
       expect(image.data['image1']).to be_present
+    end
+  end
+
+  it 'inherits superclass uploaders' do
+    with_image do |file|
+      image.base_image = file
+      image.save!
+
+      expect(image.data['base_image']).to be_present
+    end
+  end
+
+  describe 'model with the regular uploader and same name as serialized uploader' do
+    before do
+      Image.new
+    end
+
+    it 'mounts uploader to regular field' do
+      avatar = Avatar.new
+
+      expect(avatar.image1).to be_instance_of ImageUploader
     end
   end
 end


### PR DESCRIPTION
When two models have uploaders with the same name, and one of the uploaders is serialized, another (not serialized uploader) was expected in that serialized field.

`SecondModel` has `serialized_uploaders` which points to `image_data` which does not exist in that model:
```ruby
class FirstModel
  mount_uploader :image, ImageUploader, serialize_to: :image_data
end

class SecondModel
  mount_uploader :image, ImageUploader
end
``` 

This PR uses approach of #18 and fixes this behaviour